### PR TITLE
Remove cloudformation dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ The module supports connecting to an existing CloudTrail trail. This requires 3 
 3. Supplying the ARN of the SNS used by the trail to notify of new logs, in `existing_sns_arn`. 
 This can be configured manually on the existing trail. 
 
+### Creating a CloudTrail trail and other infrastructure in seperate AWS accounts
+This module supports creating a CloudTrail trail in one account, and creating the rest of the infrastructure in a seperate account.
+This may be optimal in cases where you want an organization trail from the organization master, but you want it to send logs to a bucket in a logs account.
+
+#### In the bucket destination account
+1. Set `create_cloudtrail` to false.
+2. Set `source_account_id` to the account that will host the cloudtrail
+
+#### In the trail source account
+1. Set `existing_bucket_name`, `existing_kms_key_arn`, and `existing_sns_arn` to values output in the previous step
+2. Set `create_bridgecrew_connection` to false
+
+In both accounts, be sure to set the `organization_id` if this is an organization-wide trail.
+
 ### Importing existing AWS CloudFormation 
 WIP
 
@@ -31,11 +45,18 @@ WIP
 |---|---|---|---|---|---|
 | company_name| YES | String | | testcustomer | The name of the customer. Must be alphanumeric. |
 | account_alias | NO | String |  | prod | The alias of the account the CF is deployed in. This will be prepended to all the resources in the stack. Default is {company_name}-bc |
-| create_cloudtrail | NO | Boolean | true | false | Indicate whther a new CloudTrail trail should be created. If not - existing_sns_arn and existing_bucket_name are required parameters. |
+| create_cloudtrail | NO | Boolean | true | false | Indicate whether a new CloudTrail trail should be created. |
+| create_bridgecrew_connection | NO | Boolean | true | false | Indicate whether an SNS queue and role for Bridgecrew should be created in this account. |
 | log_file_prefix | NO | String |  | cloudtrail | The prefix which will be given to all the log files saved to the bucket. |
-| existing_sns_arn | NO | String | | arn:aws:sns:us-east-1:090772183824:test-bc-bridgecrewcws | When connecting to an existing CloudTrail trail, please supply the existing trail's SNS ARN. |
-| existing_bucket_name | NO | String | | test-bc-bridgecrewcws | When connecting to an existing CloudTrail trail, please supply the existing trail's bucket name (NOT ARN). |
+| existing_sns_arn | NO | String | | arn:aws:sns:us-east-1:090772183824:test-bc-bridgecrewcws | When connecting to an existing SNS topic, please supply the trail's SNS ARN. |
+| existing_bucket_name | NO | String | | test-bc-bridgecrewcws | When connecting to an existing CloudTrail bucket, please supply the bucket name (NOT ARN). |
+| existing_kms_key_arn | NO | String | | arn:aws:kms:us-east-1:090772183824:key/c79ebdc6-bb68-4e83-805f-be5304c10f1e | When using an existing KMS Key (to be accessed by Bridgecrew), specify the existing KMS key ARN. |
 | security_account_id | NO | String | "" | 12345678900 | When connecting to a centralized CloudTrail bucket setup, please supply the ID of the AWS account that hosts the CloudTrail log bucket. We must be deployed in that central logging account beforehand for the integration to work correctly. |
+| source_account_id | NO | String | | 090772183824 | When cloudtrail in another account is connecting to buckets and sns topics in this account, specify the account ID of that account. |
+| organization_id | NO | String | | o-sv720a91a0 | When creating an organization-wide cloudtrail from the organization master. |
+| logs_bucket_id | NO | String | | cloudtrail-logs-bucket | Bucket to place access logs from the cloudtrail bucket (defaults to no logs) |
+| logs_file_expiration | NO | Number | 30 | 90 | How long to keep Cloudtrail logs in the bucket. |
+| debug_policy | NO | Bool | true | false | Whether to give Bridgecrew read-only debugging access. |
 
 ## Outuput
 | Name |  Example Value | Description |

--- a/cloudtrail_trail.tf
+++ b/cloudtrail_trail.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudtrail" "trail" {
+  count          = var.create_cloudtrail ? 1 : 0
+  depends_on     = [aws_s3_bucket_policy.bridgecrew_cws_bucket]
+  name           = "${local.resource_name_prefix}-bridgecrewcws"
+  s3_bucket_name = local.s3_bucket
+  s3_key_prefix  = var.log_file_prefix
+
+  sns_topic_name = local.sns_topic
+  kms_key_id     = local.kms_key
+
+  enable_log_file_validation    = true
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  is_organization_trail         = var.organization_id != ""
+  enable_logging                = true
+
+}
+

--- a/iam_bridgecrew_cws_policy.tf
+++ b/iam_bridgecrew_cws_policy.tf
@@ -1,0 +1,88 @@
+resource "aws_iam_policy" "bridgecrew_cws_policy" {
+  count  = var.create_bridgecrew_connection ? 1 : 0
+  name   = "bridgecrew_cws_policy"
+  policy = data.aws_iam_policy_document.bridgecrew_cws_policy[0].json
+}
+
+data "aws_iam_policy_document" "bridgecrew_cws_policy" {
+  count = var.create_bridgecrew_connection ? 1 : 0
+  statement {
+    sid = "ConsumeNotifications"
+    actions = [
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:DeleteMessage",
+      "sqs:ReceiveMessage",
+    ]
+
+    effect = "Allow"
+
+    resources = [aws_sqs_queue.cloudtrail_queue[0].arn]
+  }
+
+  statement {
+    sid = "ListLogFiles"
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    effect = "Allow"
+
+    resources = ["arn:aws:s3:::${local.s3_bucket}/AWSLogs/*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["AWSLogs/*"]
+    }
+  }
+
+  statement {
+    sid = "ReadLogFiles"
+    actions = [
+      "s3:Get*",
+    ]
+
+    effect = "Allow"
+
+    resources = ["arn:aws:s3:::${local.s3_bucket}/AWSLogs/*"]
+  }
+
+  statement {
+    sid = "GetAccountAlias"
+    actions = [
+      "iam:ListAccountAliases",
+    ]
+
+    effect = "Allow"
+
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.debug_policy ? ["Debug"] : []
+    content {
+      sid = each.value
+      actions = [
+        "cloudtrail:DescribeTrails",
+        "cloudtrail:GetTrailTopics",
+        "cloudtrail:GetTrailStatus",
+        "cloudtrail:ListPublicKeys",
+        "s3:GetBucketAcl",
+        "s3:GetBucketPolicy",
+        "s3:ListAllMyBuckets",
+        "s3:GetBucketLocation",
+        "s3:GetBucketLogging",
+        "sns:GetSubscriptionAttributes",
+        "sns:GetTopicAttributes",
+        "sns:ListSubscriptions",
+        "sns:ListSubscriptionsByTopic",
+        "sns:ListTopics"
+      ]
+
+      effect = "Allow"
+
+      resources = ["*"]
+    }
+  }
+}

--- a/iam_bridgecrew_role.tf
+++ b/iam_bridgecrew_role.tf
@@ -1,0 +1,45 @@
+resource "aws_iam_role" "bridgecrew_account_role" {
+  count              = var.create_bridgecrew_connection ? 1 : 0
+  name               = "${local.resource_name_prefix}-bridgecrewcwssarole"
+  assume_role_policy = data.aws_iam_policy_document.bridgecrew_account_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "bridgecrew_account_assume_role" {
+  count = var.create_bridgecrew_connection ? 1 : 0
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.bridgecrew_account_id}:root"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [random_string.external_id.result]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "bridgecrew_security_audit" {
+  count      = var.create_bridgecrew_connection ? 1 : 0
+  role       = aws_iam_role.bridgecrew_account_role[0].name
+  policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+}
+
+resource "aws_iam_role_policy_attachment" "bridgecrew_cloud_formation" {
+  count      = var.create_bridgecrew_connection ? 1 : 0
+  role       = aws_iam_role.bridgecrew_account_role[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "bridgecrew_cws_policy" {
+  count      = var.create_bridgecrew_connection ? 1 : 0
+  role       = aws_iam_role.bridgecrew_account_role[0].name
+  policy_arn = aws_iam_policy.bridgecrew_cws_policy[0].arn
+}

--- a/kms_cloudtrail_key.tf
+++ b/kms_cloudtrail_key.tf
@@ -1,0 +1,107 @@
+resource "aws_kms_key" "cloudtrail_key" {
+  count               = var.existing_kms_key_arn == null ? 1 : 0
+  description         = "KMS for Cloudtrail, shared with Lacework and Bridgecrew"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.cloudtrail_key[0].json
+}
+
+resource "aws_kms_alias" "cloudtrail_key" {
+  count         = var.existing_kms_key_arn == null ? 1 : 0
+  name          = "alias/${local.resource_name_prefix}-CloudtrailKey"
+  target_key_id = aws_kms_key.cloudtrail_key[0].key_id
+}
+
+
+data "aws_iam_policy_document" "cloudtrail_key" {
+  count = var.existing_kms_key_arn == null ? 1 : 0
+  statement {
+    sid = "AccountOwner"
+
+    actions = [
+      "kms:*",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+    }
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "CloudTrailEncrypt"
+    actions = [
+      "kms:GenerateDataKey*",
+      "kms:ReEncryptFrom",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:cloudtrail:arn"
+      values = [
+        "arn:aws:cloudtrail:*:${var.source_account_id != "" ? var.source_account_id : local.account_id}:trail/*"
+      ]
+    }
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "CloudTrailDescribe"
+    actions = [
+      "kms:DescribeKey",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "BridgecrewDecrypt"
+    actions = [
+      "kms:Decrypt",
+      "kms:ReEncryptFrom",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+      values   = [var.source_account_id != "" ? var.source_account_id : local.account_id]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:cloudtrail:arn"
+      values = [
+        "arn:aws:cloudtrail:*:${
+          var.source_account_id != "" ? var.source_account_id : local.account_id
+        }:trail/*"
+      ]
+    }
+
+    resources = ["*"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,16 @@
 locals {
-  resource_name_prefix = var.account_alias == "" ? "${var.company_name}-bc" : "${var.company_name}-${var.account_alias}"
+  resource_name_prefix  = var.account_alias == "" ? "${var.company_name}-bc" : "${var.company_name}-${var.account_alias}"
+  bridgecrew_account_id = "890234264427"
+
+  s3_bucket  = var.existing_bucket_name == null ? aws_s3_bucket.bridgecrew_cws_bucket[0].bucket : var.existing_bucket_name
+  kms_key    = var.existing_kms_key_arn == null ? aws_kms_key.cloudtrail_key[0].arn : var.existing_kms_key_arn
+  sns_topic  = var.existing_sns_arn == null ? aws_sns_topic.cloudtrail_to_bridgecrew[0].arn : var.existing_sns_arn
+  account_id = data.aws_caller_identity.caller.account_id
 }
+
+data "aws_caller_identity" "caller" {}
+
+data "aws_region" "region" {}
 
 resource "random_string" "external_id" {
   length  = 6
@@ -8,18 +18,3 @@ resource "random_string" "external_id" {
   special = false
 }
 
-resource "aws_cloudformation_stack" "bridgecrew_stack" {
-  name         = "${local.resource_name_prefix}-bridgecrew"
-  template_url = "https://bc-cf-template-890234264427-prod.s3-us-west-2.amazonaws.com/cloud-formation-template.json"
-  capabilities = ["CAPABILITY_NAMED_IAM"]
-  parameters = {
-    ResourceNamePrefix : local.resource_name_prefix
-    CustomerName : var.company_name
-    ExternalID : random_string.external_id.result
-    CreateTrail : var.create_cloudtrail ? "Yes" : "No"
-    NewTrailLogFilePrefix : var.create_cloudtrail ? var.log_file_prefix : ""
-    ExistingTrailBucketName : var.create_cloudtrail ? "" : var.existing_bucket_name
-    ExistingTrailTopicArn : var.create_cloudtrail ? "" : var.existing_sns_arn
-    SecurityAccountId: var.security_account_id
-  }
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,49 @@
-output "cloudformation_arn" {
-  value       = aws_cloudformation_stack.bridgecrew_stack.id
-  description = "The ID of the CloudFormation that was created."
+output "s3_bucket_name" {
+  description = "The s3 bucket name for cloudtrail."
+  value       = local.s3_bucket
+}
+
+output "s3_key_prefix" {
+  description = "The s3 log prefix for cloudtrail, inside the bucket."
+  value       = var.log_file_prefix
+}
+
+output "sns_topic_name" {
+  description = "The sns topic cloudtrail will push to."
+  value       = local.sns_topic
+}
+
+output "kms_key_id" {
+  description = "The KMS key cloudtrail will use for encryption"
+  value       = local.kms_key
+}
+
+output "role_arn" {
+  description = "The cross-account access role ARN for Bridgecrew"
+  value       = aws_iam_role.bridgecrew_account_role[0].arn
+}
+
+output "customer_name" {
+  description = "The customer name as defined on Bridgecrew signup"
+  value       = var.company_name
+}
+
+output "sqs_queue_arn" {
+  description = "The SQS queue ARN to share with Bridgecrew for CloudTrail integration"
+  value       = aws_sqs_queue.cloudtrail_queue[0].arn
+}
+
+output "sqs_queue_url" {
+  description = "The SQS queue URL to share with Bridgecrew for CloudTrail integration"
+  value       = aws_sqs_queue.cloudtrail_queue[0].id
+}
+
+output "deployment_region" {
+  description = "The region that the customer ran this module"
+  value       = data.aws_region.region.name
+}
+
+output "template_version" {
+  description = "Bridgecrew.io template version."
+  value       = "1.4"
 }

--- a/s3_cloudtrail_bucket.tf
+++ b/s3_cloudtrail_bucket.tf
@@ -1,0 +1,151 @@
+locals {
+  bucket_name = "${local.resource_name_prefix}-bridgecrewcws-${local.account_id}"
+}
+
+resource "aws_s3_bucket" "bridgecrew_cws_bucket" {
+  count = var.existing_bucket_name == null ? 1 : 0
+
+  bucket = local.bucket_name
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "Delete old log files"
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = var.log_file_expiration
+    }
+
+    expiration {
+      days = var.log_file_expiration
+    }
+  }
+
+  dynamic "logging" {
+    for_each = var.logs_bucket_id != null ? [var.logs_bucket_id] : []
+
+    content {
+      target_bucket = logging.value
+      target_prefix = "/${local.bucket_name}"
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = local.kms_key
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  tags = {
+    Name = "BridgecrewCWSBucket"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "bridgecrew_cws_bucket" {
+  count  = var.existing_bucket_name == null ? 1 : 0
+  bucket = aws_s3_bucket.bridgecrew_cws_bucket[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_iam_policy_document" "bridgecrew_cws_bucket" {
+  count = var.existing_bucket_name == null ? 1 : 0
+  statement {
+    sid       = "CloudTrailAclCheck"
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.bridgecrew_cws_bucket[0].arn]
+    effect    = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid       = "CloudTrailWrite"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.bridgecrew_cws_bucket[0].arn}/${var.log_file_prefix}${var.log_file_prefix != "" ? "/" : ""}AWSLogs/${var.source_account_id != "" ? var.source_account_id : local.account_id}/*"]
+    effect    = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["True"]
+    }
+  }
+
+
+  dynamic "statement" {
+    for_each = var.organization_id != "" ? [var.organization_id] : []
+
+    content {
+      sid       = "OrgCloudTrailWrite"
+      actions   = ["s3:PutObject"]
+      resources = ["${aws_s3_bucket.bridgecrew_cws_bucket[0].arn}/${var.log_file_prefix}${var.log_file_prefix != "" ? "/" : ""}AWSLogs/${statement.value}/*"]
+      effect    = "Allow"
+
+      principals {
+        type        = "Service"
+        identifiers = ["cloudtrail.amazonaws.com"]
+      }
+
+      condition {
+        test     = "StringEquals"
+        variable = "s3:x-amz-acl"
+        values   = ["bucket-owner-full-control"]
+      }
+
+      condition {
+        test     = "Bool"
+        variable = "aws:SecureTransport"
+        values   = ["True"]
+      }
+    }
+  }
+
+  statement {
+    sid       = "DenyUnsecureTransport"
+    actions   = ["s3:*"]
+    resources = ["${aws_s3_bucket.bridgecrew_cws_bucket[0].arn}/*"]
+    effect    = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["False"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "bridgecrew_cws_bucket" {
+  count  = var.existing_bucket_name == null ? 1 : 0
+  bucket = aws_s3_bucket.bridgecrew_cws_bucket[0].id
+  policy = data.aws_iam_policy_document.bridgecrew_cws_bucket[0].json
+}

--- a/sns_cloudtrail_topic.tf
+++ b/sns_cloudtrail_topic.tf
@@ -1,0 +1,30 @@
+resource "aws_sns_topic" "cloudtrail_to_bridgecrew" {
+  count = var.existing_sns_arn == null ? 1 : 0
+  name  = "${local.resource_name_prefix}-bridgecrewcws"
+}
+
+data "aws_iam_policy_document" "cloudtrail_to_bridgecrew" {
+  count = var.existing_sns_arn == null ? 1 : 0
+  statement {
+    sid     = "CloudTrailPublish"
+    actions = ["SNS:Publish"]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_sns_topic_policy" "cloudtrail_to_bridgecrew" {
+  count  = var.existing_sns_arn == null ? 1 : 0
+  arn    = aws_sns_topic.cloudtrail_to_bridgecrew[0].arn
+  policy = data.aws_iam_policy_document.cloudtrail_to_bridgecrew[0].json
+}
+

--- a/sqs_cloudtrail_queue.tf
+++ b/sqs_cloudtrail_queue.tf
@@ -1,0 +1,63 @@
+resource "aws_sqs_queue" "cloudtrail_queue" {
+  count                      = var.create_bridgecrew_connection ? 1 : 0
+  name                       = "${local.resource_name_prefix}-bridgecrewcws"
+  visibility_timeout_seconds = 43200
+  policy                     = data.aws_iam_policy_document.cloudtrail_queue[0].json
+}
+
+resource "aws_sns_topic_subscription" "cloudtrail_queue" {
+  count     = var.create_bridgecrew_connection ? 1 : 0
+  topic_arn = local.sns_topic
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.cloudtrail_queue[0].arn
+}
+
+data "aws_iam_policy_document" "cloudtrail_queue" {
+  count = var.create_bridgecrew_connection ? 1 : 0
+  statement {
+    sid = "AllowSnsAccess"
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [local.sns_topic]
+    }
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid = "BridgecrewSnsAccess"
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:GetQueueUrl",
+      "sqs:ListDeadLetterSourceQueues",
+      "sqs:ChangeMessageVisibility",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.bridgecrew_account_id}:root"]
+    }
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "company_name" {
-  type        = string
   description = "The name of the company the integration is for. Must be alphanumeric."
+  type        = string
 }
 
 variable "account_alias" {
@@ -10,7 +10,13 @@ variable "account_alias" {
 }
 
 variable "create_cloudtrail" {
-  description = "Indicate whther a new CloudTrail trail should be created. If not - existing_sns_arn and existing_bucket_name are required parameters."
+  description = "Indicate whether a new CloudTrail trail should be created. If not - existing_sns_arn and existing_bucket_name are required parameters."
+  type        = bool
+  default     = true
+}
+
+variable "create_bridgecrew_connection" {
+  description = "Indicate whether the SQS queue and IAM policies for Bridgecrew need to be set up.  This may be false if you are connecting a cloudtrail in a new account to an existing bucket."
   type        = bool
   default     = true
 }
@@ -33,8 +39,42 @@ variable "existing_bucket_name" {
   default     = null
 }
 
+variable "existing_kms_key_arn" {
+  description = "When connecting to an existing CloudTrail trail, please supply the kms key ARN used to encrypt"
+  type        = string
+  default     = null
+}
+
 variable "security_account_id" {
   description = "When connecting to an existing CloudTrail trail, which puts its logs in a bucket which is in **another** account"
   type        = string
   default     = ""
+}
+
+variable "source_account_id" {
+  description = "Account that need access to connect to the cloudtrail created by this module"
+  type        = string
+  default     = ""
+}
+
+variable "organization_id" {
+  description = "ID or the organization (for org-wide cloudtrails)"
+  type        = string
+  default     = ""
+}
+
+variable "logs_bucket_id" {
+  description = "Bucket to place access logs from the cloudtrail bucket"
+  type        = string
+  default     = null
+}
+
+variable "log_file_expiration" {
+  type    = number
+  default = 30
+}
+
+variable "debug_policy" {
+  type    = bool
+  default = true
 }


### PR DESCRIPTION
This PR:
* Removes any dependency on CloudFormation
* Allows us to have an organization-wide trail in one account; we can keep its bucket, sns topic, sqs queue, roles, and policies in another account
* Adds a couple more options for more advanced setups

This PR does not include the BridgecrewSNSCustomResource that was originally in the Cloudformation.