### PR TITLE
Use policy json instead of full object

### DIFF
--- a/iam_bridgecrew_role.tf
+++ b/iam_bridgecrew_role.tf
@@ -45,7 +45,7 @@ data aws_iam_policy_document "bridgecrew_describe_policy_document" {
 
 resource aws_iam_role_policy "bridgecrew_describe_policy" {
   count  = var.create_bridgecrew_connection ? 1 : 0
-  policy = data.aws_iam_policy_document.bridgecrew_describe_policy_document
+  policy = data.aws_iam_policy_document.bridgecrew_describe_policy_document.json
   name   = "BridgecrewDescribePolicy"
   role   = aws_iam_role.bridgecrew_account_role[0].id
 }


### PR DESCRIPTION
The policy was using the entire object instead of just the output json.

```
Error: Incorrect attribute value type

  on .terraform/modules/bridgecrew-read-only/iam_bridgecrew_role.tf line 45, in resource "aws_iam_role_policy" "bridgecrew_describe_policy":
  45:   policy = data.aws_iam_policy_document.bridgecrew_describe_policy_document
    |----------------
    | data.aws_iam_policy_document.bridgecrew_describe_policy_document is object with 7 attributes

Inappropriate value for attribute "policy": string required.
```